### PR TITLE
Release 0.7.2: raise for HTTP status per request

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // See https://aka.ms/vscode-remote/devcontainer.json for format details.
 {
   "name": "Meteo.Lt Pkg Dev",
-  "image": "python:3.12-bullseye",
+  "image": "python:3.14-bookworm",
   "postCreateCommand": "python -m pip install --upgrade pip && python -m pip install -r requirements.txt",
   "runArgs": [
     "-e",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.11", "3.12", "3.13"]
+        python: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## Release 0.7.2
+
+Date: `2026-07-11`
+
+### Bug Fixes
+
+- **Raise for HTTP status per request** so error handling works with an injected `aiohttp` session, not only library-created ones
+  - Previously `raise_for_status=True` was only set on sessions the client created itself, so an externally injected session (e.g. Home Assistant's shared session) would parse 4xx/5xx bodies as payloads instead of raising `aiohttp.ClientError`
+  - Each fetch method now calls `response.raise_for_status()` on every request
+
+### Maintenance
+
+- Added Python 3.14 to the CI test matrix and bumped the devcontainer base image to `python:3.14-bookworm`
+
 ## Release 0.7.1
 
 Date: `2026-02-10`

--- a/meteo_lt/client.py
+++ b/meteo_lt/client.py
@@ -59,6 +59,7 @@ class MeteoLtClient:
         """Gets all places from API"""
         session = await self._get_session()
         async with session.get(f"{BASE_URL}/places") as response:
+            response.raise_for_status()
             response.encoding = ENCODING
             response_json = await response.json()
             return [Place.from_dict(place) for place in response_json]
@@ -67,6 +68,7 @@ class MeteoLtClient:
         """Retrieves forecast data from API"""
         session = await self._get_session()
         async with session.get(f"{BASE_URL}/places/{place_code}/forecasts/long-term") as response:
+            response.raise_for_status()
             response.encoding = ENCODING
             response_json = await response.json()
             return Forecast.from_dict(response_json)
@@ -77,6 +79,7 @@ class MeteoLtClient:
 
         # Get the latest warnings file
         async with session.get(warnings_url) as response:
+            response.raise_for_status()
             file_list = await response.json()
 
         if not file_list:
@@ -85,6 +88,7 @@ class MeteoLtClient:
         # Fetch the latest warnings data
         latest_file_url = file_list[0]  # First file is the most recent
         async with session.get(latest_file_url) as response:
+            response.raise_for_status()
             text_data = await response.text()
             return json.loads(text_data)
 
@@ -92,6 +96,7 @@ class MeteoLtClient:
         """Get list of all hydrological stations."""
         session = await self._get_session()
         async with session.get(f"{BASE_URL}/hydro-stations") as resp:
+            resp.raise_for_status()
             if resp.status == 200:
                 resp.encoding = ENCODING
                 response = await resp.json()
@@ -105,6 +110,7 @@ class MeteoLtClient:
         """Get information about a specific hydrological station."""
         session = await self._get_session()
         async with session.get(f"{BASE_URL}/hydro-stations/{station_code}") as resp:
+            resp.raise_for_status()
             if resp.status == 200:
                 resp.encoding = ENCODING
                 response = await resp.json()
@@ -122,6 +128,7 @@ class MeteoLtClient:
         async with session.get(
             f"{BASE_URL}/hydro-stations/{station_code}/observations/{observation_type}/{date}"
         ) as resp:
+            resp.raise_for_status()
             if resp.status == 200:
                 response = await resp.json()
                 station = HydroStation.from_dict(response.get("station"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "meteo_lt-pkg"
-version = "0.7.1"
+version = "0.7.2"
 authors = [
   { name="Brunas", email="brunonas@gmail.com" },
 ]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,7 +4,7 @@
 
 import json
 from datetime import datetime, timedelta, timezone
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
 import pytest
@@ -42,7 +42,7 @@ async def test_fetch_places(client):
     with patch("aiohttp.ClientSession.get") as mock_get:
         mock_response = AsyncMock()
         mock_response.json.return_value = mock_places_data
-        mock_response.raise_for_status.return_value = None
+        mock_response.raise_for_status = MagicMock()
         mock_response.encoding = "utf-8"
         mock_get.return_value.__aenter__.return_value = mock_response
 
@@ -87,7 +87,7 @@ async def test_fetch_forecast(client, tomorrow_date):
     with patch("aiohttp.ClientSession.get") as mock_get:
         mock_response = AsyncMock()
         mock_response.json.return_value = mock_forecast_data
-        mock_response.raise_for_status.return_value = None
+        mock_response.raise_for_status = MagicMock()
         mock_response.encoding = "utf-8"
         mock_get.return_value.__aenter__.return_value = mock_response
 
@@ -130,11 +130,11 @@ async def test_fetch_weather_warnings(client, tomorrow_date):
     with patch("aiohttp.ClientSession.get") as mock_get:
         mock_list_response = AsyncMock()
         mock_list_response.json.return_value = mock_file_list
-        mock_list_response.raise_for_status.return_value = None
+        mock_list_response.raise_for_status = MagicMock()
 
         mock_data_response = AsyncMock()
         mock_data_response.text.return_value = json.dumps(mock_warnings_data)
-        mock_data_response.raise_for_status.return_value = None
+        mock_data_response.raise_for_status = MagicMock()
 
         mock_get.return_value.__aenter__.side_effect = [mock_list_response, mock_data_response]
 
@@ -151,7 +151,7 @@ async def test_fetch_weather_warnings_empty(client):
     with patch("aiohttp.ClientSession.get") as mock_get:
         mock_response = AsyncMock()
         mock_response.json.return_value = []
-        mock_response.raise_for_status.return_value = None
+        mock_response.raise_for_status = MagicMock()
         mock_get.return_value.__aenter__.return_value = mock_response
 
         async with client:
@@ -177,7 +177,7 @@ async def test_fetch_hydro_stations(client):
         mock_response = AsyncMock()
         mock_response.json.return_value = mock_data
         mock_response.status = 200
-        mock_response.raise_for_status.return_value = None
+        mock_response.raise_for_status = MagicMock()
         mock_get.return_value.__aenter__.return_value = mock_response
 
         async with client:
@@ -201,7 +201,7 @@ async def test_fetch_hydro_station(client):
         mock_response = AsyncMock()
         mock_response.json.return_value = mock_data
         mock_response.status = 200
-        mock_response.raise_for_status.return_value = None
+        mock_response.raise_for_status = MagicMock()
         mock_get.return_value.__aenter__.return_value = mock_response
 
         async with client:
@@ -236,7 +236,7 @@ async def test_fetch_hydro_observation_data(client):
         mock_response = AsyncMock()
         mock_response.json.return_value = mock_data
         mock_response.status = 200
-        mock_response.raise_for_status.return_value = None
+        mock_response.raise_for_status = MagicMock()
         mock_get.return_value.__aenter__.return_value = mock_response
 
         async with client:
@@ -262,11 +262,50 @@ async def test_hydro_api_errors(client, method_name, args, status_code):
     with patch("aiohttp.ClientSession.get") as mock_get:
         mock_response = AsyncMock()
         mock_response.status = status_code
+        mock_response.raise_for_status = MagicMock()
         mock_get.return_value.__aenter__.return_value = mock_response
 
         with pytest.raises(Exception, match=f"API returned status {status_code}"):
             async with client:
                 method = getattr(client, method_name)
+                await method(*args)
+
+
+# Tests - Injected Session Error Handling
+@pytest.mark.parametrize(
+    "method_name,args",
+    [
+        ("fetch_forecast", ("lapės",)),
+        ("fetch_places", ()),
+    ],
+)
+@pytest.mark.asyncio
+async def test_injected_session_raises_for_http_error(method_name, args):
+    """A 500 must raise even when the session has no session-level raise_for_status.
+
+    This mirrors the Home Assistant scenario, where the shared aiohttp session is
+    injected via ``MeteoLtClient(session=...)`` and is created without
+    ``raise_for_status=True``. Errors must still propagate as ``aiohttp.ClientError``
+    instead of being parsed as payloads.
+    """
+    error = aiohttp.ClientResponseError(
+        request_info=AsyncMock(),
+        history=(),
+        status=500,
+        message="Internal Server Error",
+    )
+
+    async with aiohttp.ClientSession() as external_session:
+        client = MeteoLtClient(session=external_session)
+
+        with patch("aiohttp.ClientSession.get") as mock_get:
+            mock_response = AsyncMock()
+            mock_response.status = 500
+            mock_response.raise_for_status = MagicMock(side_effect=error)
+            mock_get.return_value.__aenter__.return_value = mock_response
+
+            method = getattr(client, method_name)
+            with pytest.raises(aiohttp.ClientResponseError):
                 await method(*args)
 
 


### PR DESCRIPTION
## Summary

In 0.7.1, `MeteoLtClient` only enabled `raise_for_status=True` on sessions it creates itself. When an aiohttp session is **injected** via `MeteoLtAPI(session=...)` — as the Home Assistant `meteo_lt` integration does — HTTP 4xx/5xx responses were **not** raised; error bodies got parsed as payloads and bypassed the caller's `aiohttp.ClientError` handling. This is a regression from 0.2.4, which raised per request.

## Changes

- **`meteo_lt/client.py`**: call `response.raise_for_status()` as the first statement in every `session.get(...)` block across all fetch methods (`fetch_places`, `fetch_forecast`, `fetch_warnings` — both requests, `fetch_hydro_stations`, `fetch_hydro_station`, `fetch_hydro_observation_data`). Errors now raise regardless of session ownership.
- **Tests**: added `test_injected_session_raises_for_http_error`, which injects a session without session-level `raise_for_status` and asserts a mocked 500 makes `fetch_forecast` and `fetch_places` raise `aiohttp.ClientResponseError` (the exact HA scenario). Existing `raise_for_status` mocks switched from async to synchronous `MagicMock` to match aiohttp's sync API and silence "coroutine never awaited" warnings.
- **Maintenance**: added Python 3.14 to the CI matrix; bumped the devcontainer base image to `python:3.14-bookworm`.
- Version bump 0.7.1 → 0.7.2 and CHANGELOG entry.

## Verification

Full suite (151 tests) passes in the devcontainer image on both Python 3.12 and 3.14.