### PR TITLE
Release 0.7.3: per-request timeout, session-agnostic client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## Release 0.7.3
+
+Date: `2026-07-12`
+
+### Bug Fixes
+
+- **Per-request timeout on every request** so the configured `30s` timeout applies with an injected `aiohttp` session, not only library-created ones
+  - Previously `ClientTimeout(total=30)` was only set on sessions the client created itself, so an externally injected session (e.g. Home Assistant's shared session) would fall back to aiohttp's ~5 minute default, letting a stalled request block setup for minutes
+  - Every fetch method now passes `timeout=aiohttp.ClientTimeout(total=TIMEOUT)` on each request
+- **Non-2xx hydro responses now raise instead of returning `None`**: removed the dead `if status == 200` branch in the hydro methods (unreachable after `raise_for_status()`); a `2xx`-non-`200` response no longer falls through silently
+
+### Changes
+
+- **Consistent response encoding**: the second warnings request and hydro observation request now set `response.encoding = "utf-8"` like the other requests, so Lithuanian characters decode correctly
+
 ## Release 0.7.2
 
 Date: `2026-07-11`

--- a/meteo_lt/client.py
+++ b/meteo_lt/client.py
@@ -58,7 +58,7 @@ class MeteoLtClient:
     async def fetch_places(self) -> List[Place]:
         """Gets all places from API"""
         session = await self._get_session()
-        async with session.get(f"{BASE_URL}/places") as response:
+        async with session.get(f"{BASE_URL}/places", timeout=aiohttp.ClientTimeout(total=TIMEOUT)) as response:
             response.raise_for_status()
             response.encoding = ENCODING
             response_json = await response.json()
@@ -67,7 +67,10 @@ class MeteoLtClient:
     async def fetch_forecast(self, place_code: str) -> Forecast:
         """Retrieves forecast data from API"""
         session = await self._get_session()
-        async with session.get(f"{BASE_URL}/places/{place_code}/forecasts/long-term") as response:
+        async with session.get(
+            f"{BASE_URL}/places/{place_code}/forecasts/long-term",
+            timeout=aiohttp.ClientTimeout(total=TIMEOUT),
+        ) as response:
             response.raise_for_status()
             response.encoding = ENCODING
             response_json = await response.json()
@@ -78,7 +81,7 @@ class MeteoLtClient:
         session = await self._get_session()
 
         # Get the latest warnings file
-        async with session.get(warnings_url) as response:
+        async with session.get(warnings_url, timeout=aiohttp.ClientTimeout(total=TIMEOUT)) as response:
             response.raise_for_status()
             file_list = await response.json()
 
@@ -87,35 +90,35 @@ class MeteoLtClient:
 
         # Fetch the latest warnings data
         latest_file_url = file_list[0]  # First file is the most recent
-        async with session.get(latest_file_url) as response:
+        async with session.get(latest_file_url, timeout=aiohttp.ClientTimeout(total=TIMEOUT)) as response:
             response.raise_for_status()
+            response.encoding = ENCODING
             text_data = await response.text()
             return json.loads(text_data)
 
     async def fetch_hydro_stations(self) -> List[HydroStation]:
         """Get list of all hydrological stations."""
         session = await self._get_session()
-        async with session.get(f"{BASE_URL}/hydro-stations") as resp:
+        async with session.get(f"{BASE_URL}/hydro-stations", timeout=aiohttp.ClientTimeout(total=TIMEOUT)) as resp:
             resp.raise_for_status()
-            if resp.status == 200:
-                resp.encoding = ENCODING
-                response = await resp.json()
-                stations = []
-                for station_data in response:
-                    stations.append(HydroStation.from_dict(station_data))
-                return stations
-            raise aiohttp.ClientError(f"API returned status {resp.status}")
+            resp.encoding = ENCODING
+            response = await resp.json()
+            stations = []
+            for station_data in response:
+                stations.append(HydroStation.from_dict(station_data))
+            return stations
 
     async def fetch_hydro_station(self, station_code: str) -> HydroStation:
         """Get information about a specific hydrological station."""
         session = await self._get_session()
-        async with session.get(f"{BASE_URL}/hydro-stations/{station_code}") as resp:
+        async with session.get(
+            f"{BASE_URL}/hydro-stations/{station_code}",
+            timeout=aiohttp.ClientTimeout(total=TIMEOUT),
+        ) as resp:
             resp.raise_for_status()
-            if resp.status == 200:
-                resp.encoding = ENCODING
-                response = await resp.json()
-                return HydroStation.from_dict(response)
-            raise aiohttp.ClientError(f"API returned status {resp.status}")
+            resp.encoding = ENCODING
+            response = await resp.json()
+            return HydroStation.from_dict(response)
 
     async def fetch_hydro_observation_data(
         self,
@@ -126,20 +129,20 @@ class MeteoLtClient:
         """Get hydrological observation data for a station."""
         session = await self._get_session()
         async with session.get(
-            f"{BASE_URL}/hydro-stations/{station_code}/observations/{observation_type}/{date}"
+            f"{BASE_URL}/hydro-stations/{station_code}/observations/{observation_type}/{date}",
+            timeout=aiohttp.ClientTimeout(total=TIMEOUT),
         ) as resp:
             resp.raise_for_status()
-            if resp.status == 200:
-                response = await resp.json()
-                station = HydroStation.from_dict(response.get("station"))
+            resp.encoding = ENCODING
+            response = await resp.json()
+            station = HydroStation.from_dict(response.get("station"))
 
-                observations = []
-                for obs_data in response.get("observations", []):
-                    observations.append(HydroObservation.from_dict(obs_data))
+            observations = []
+            for obs_data in response.get("observations", []):
+                observations.append(HydroObservation.from_dict(obs_data))
 
-                return HydroObservationData(
-                    station=station,
-                    observations_data_range=response.get("observationsDataRange"),
-                    observations=observations,
-                )
-            raise aiohttp.ClientError(f"API returned status {resp.status}")
+            return HydroObservationData(
+                station=station,
+                observations_data_range=response.get("observationsDataRange"),
+                observations=observations,
+            )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "meteo_lt-pkg"
-version = "0.7.2"
+version = "0.7.3"
 authors = [
   { name="Brunas", email="brunonas@gmail.com" },
 ]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,10 +4,11 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import aiohttp
 import pytest
 
 from meteo_lt.api import MeteoLtAPI
-from meteo_lt.const import BASE_URL
+from meteo_lt.const import BASE_URL, TIMEOUT
 from meteo_lt.models import (
     Coordinates,
     Forecast,
@@ -113,7 +114,7 @@ async def test_session_injection():
 
     await api.fetch_places()
 
-    mock_session.get.assert_called_once_with(f"{BASE_URL}/places")
+    mock_session.get.assert_called_once_with(f"{BASE_URL}/places", timeout=aiohttp.ClientTimeout(total=TIMEOUT))
     assert len(api.places) == 1
     assert api.places[0].code == "test"
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -10,7 +10,7 @@ import aiohttp
 import pytest
 
 from meteo_lt.client import MeteoLtClient
-from meteo_lt.const import WARNINGS_URL
+from meteo_lt.const import TIMEOUT, WARNINGS_URL
 
 
 @pytest.fixture
@@ -258,14 +258,25 @@ async def test_fetch_hydro_observation_data(client):
 )
 @pytest.mark.asyncio
 async def test_hydro_api_errors(client, method_name, args, status_code):
-    """Test error handling for hydro API methods"""
+    """Test error handling for hydro API methods.
+
+    A non-2xx response must raise ``aiohttp.ClientResponseError`` via
+    ``raise_for_status()`` rather than falling through and returning ``None``.
+    """
+    error = aiohttp.ClientResponseError(
+        request_info=AsyncMock(),
+        history=(),
+        status=status_code,
+        message=f"API returned status {status_code}",
+    )
+
     with patch("aiohttp.ClientSession.get") as mock_get:
         mock_response = AsyncMock()
         mock_response.status = status_code
-        mock_response.raise_for_status = MagicMock()
+        mock_response.raise_for_status = MagicMock(side_effect=error)
         mock_get.return_value.__aenter__.return_value = mock_response
 
-        with pytest.raises(Exception, match=f"API returned status {status_code}"):
+        with pytest.raises(aiohttp.ClientResponseError):
             async with client:
                 method = getattr(client, method_name)
                 await method(*args)
@@ -307,6 +318,56 @@ async def test_injected_session_raises_for_http_error(method_name, args):
             method = getattr(client, method_name)
             with pytest.raises(aiohttp.ClientResponseError):
                 await method(*args)
+
+
+# Tests - Injected Session Per-Request Timeout
+@pytest.mark.parametrize(
+    "method_name,args,mock_json",
+    [
+        (
+            "fetch_forecast",
+            ("lapės",),
+            {
+                "place": {
+                    "code": "lapės",
+                    "name": "Lapės",
+                    "administrativeDivision": "Kauno rajono savivaldybė",
+                    "countryCode": "LT",
+                    "coordinates": {"latitude": 54.97371, "longitude": 24.00048},
+                },
+                "forecastCreationTimeUtc": "2024-01-01 12:00:00",
+                "forecastTimestamps": [],
+            },
+        ),
+        ("fetch_places", (), []),
+    ],
+)
+@pytest.mark.asyncio
+async def test_injected_session_carries_per_request_timeout(method_name, args, mock_json):
+    """Every request must carry ``ClientTimeout(total=TIMEOUT)`` even when the
+    injected session was created without a session-level timeout.
+
+    This mirrors the Home Assistant scenario, where the shared aiohttp session is
+    injected via ``MeteoLtClient(session=...)``. Without a per-request timeout a
+    stalled request would fall back to aiohttp's ~5 minute default and block setup.
+    """
+    async with aiohttp.ClientSession() as external_session:
+        client = MeteoLtClient(session=external_session)
+
+        with patch("aiohttp.ClientSession.get") as mock_get:
+            mock_response = AsyncMock()
+            mock_response.json.return_value = mock_json
+            mock_response.raise_for_status = MagicMock()
+            mock_response.encoding = "utf-8"
+            mock_get.return_value.__aenter__.return_value = mock_response
+
+            method = getattr(client, method_name)
+            await method(*args)
+
+            assert mock_get.call_count == 1
+            timeout = mock_get.call_args.kwargs["timeout"]
+            assert isinstance(timeout, aiohttp.ClientTimeout)
+            assert timeout.total == TIMEOUT
 
 
 # Tests - Session Management


### PR DESCRIPTION
## Summary

Makes `MeteoLtClient` fully **session-agnostic**: an externally injected `aiohttp` session (e.g. Home Assistant's shared `async_get_clientsession`) now gets the same behavior as a library-created one. Follows up 0.7.2, which fixed `raise_for_status` per request but left the timeout session-only.

## Changes

- **Per-request timeout on every request** — `timeout=aiohttp.ClientTimeout(total=TIMEOUT)` on all seven `session.get(...)` calls across the six fetch methods. Previously `ClientTimeout(total=30)` was set only on the self-created session, so an injected session fell back to aiohttp's ~5 minute default — a stalled request could block setup/coordinator/config-flow for minutes (regression vs 0.2.4).
- **Simplified hydro methods** — dropped the dead `if resp.status == 200: ... else raise ClientError` branch in `fetch_hydro_stations`, `fetch_hydro_station`, and `fetch_hydro_observation_data`. It was unreachable for errors after `raise_for_status()`, and a `2xx`-non-`200` (e.g. `204`) fell through returning `None`. Now parses directly after `raise_for_status()`, so non-2xx raises.
- **Consistent response encoding** — the second warnings request (`.text()` + `json.loads`) and the hydro observation request now set `response.encoding = ENCODING` like the others, so Lithuanian UTF-8 characters decode correctly.

## Tests

- New: assert every request carries `ClientTimeout(total=30)` when an injected session has **no** session-level timeout (`fetch_forecast` + `fetch_places`).
- Updated hydro error tests to assert `aiohttp.ClientResponseError` propagates from `raise_for_status()` (covers the removed `status == 200` branch — non-2xx raises instead of returning `None`).
- Updated `test_session_injection` to expect the per-request `timeout` kwarg.

153 tests pass; flake8 clean; package builds as `0.7.3`.

## Release

- `pyproject.toml` `0.7.2` → `0.7.3`
- `CHANGELOG.md` entry for `0.7.3`
- After merge: tag `v0.7.3` and publish a GitHub Release to trigger the PyPI upload workflow.